### PR TITLE
Fix AttributeError when fromId is None

### DIFF
--- a/GPXTracker.py
+++ b/GPXTracker.py
@@ -48,7 +48,10 @@ class Plugin(BasePlugin):
             return
 
         # Extract device ID
-        device_id_raw = packet.get("fromId", "")
+        device_id_raw = packet.get("fromId")
+        if not device_id_raw:
+            self.logger.debug("Message missing fromId, ignoring")
+            return
         device_id_hex = device_id_raw.lstrip("!")
 
         # Check if the device is allowed or if wildcard is enabled

--- a/GPXTracker.py
+++ b/GPXTracker.py
@@ -4,12 +4,9 @@ import gpxpy
 import os
 
 class Plugin(BasePlugin):
-    plugin_name = "gpxtracker"
-
+    plugin_name = "gpxtracker"  # Define plugin_name as a class variable
 
     def __init__(self, config_file='config.yaml'):
-        # Set plugin_name before calling super().__init__()
-        self.plugin_name = "gpxtracker"
         super().__init__()
         # Load configuration options
         self.allowed_device_ids = self.config.get('allowed_device_ids', ["*"])


### PR DESCRIPTION
Add null check for packet fromId field to prevent AttributeError when node database has not yet been populated or has been reset. This resolves the crash when trying to call lstrip() on None value.

Fixes the error: AttributeError: 'NoneType' object has no attribute 'lstrip'.

Also a minor correction to the changes I made last time.  This current change simplifies the plugin init.